### PR TITLE
use full window height for InfiniteScroll

### DIFF
--- a/pages/[contractSlug].tsx
+++ b/pages/[contractSlug].tsx
@@ -73,7 +73,7 @@ const TabWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  
+
   @media only screen and (max-width: 600px) {
     flex-direction: column;
     max-height: 100%;
@@ -97,7 +97,6 @@ const ScrollContainer = styled.div`
   margin-left: 1vw;
   margin-right: 1vw;
   overflow: hidden;
-  
 `;
 
 
@@ -172,7 +171,7 @@ function Listings({
 
   return (
     <TabWrapper>
-      { !showActivity && 
+      { !showActivity &&
         <SideBar
           collection={collection}
           selectionChange={selectionChange}
@@ -189,7 +188,7 @@ function Listings({
               hasMore={true}
               loader={null}
               scrollThreshold={0.5}
-              height={"82vh"}
+              height={"100vh"}
             >
               <ScrollContainer>
                 {listings.map((listing: any, index) => {
@@ -239,7 +238,7 @@ export default function Marketplace({
 
   if (contract) {
   return (
-    <Layout 
+    <Layout
       title={`${CONTRACTS[contract].display} ${ showActivity ? 'Activity' : 'Marketplace'}`}
       description={'Like Wizard, Buy Wizard'}
       image={'https://forgotten.market/static/img/OSFeature.png'}
@@ -251,12 +250,12 @@ export default function Marketplace({
             <CollectionOfferButton contract={contract} setShowModal={setShowModal}/>
           </div>
         </MobileHeader>
-        {showModal && 
-          <Order 
-            contract={contract} 
-            tokenId={'0'} 
-            name={CONTRACTS[contract].full} 
-            collectionWide={true} 
+        {showModal &&
+          <Order
+            contract={contract}
+            tokenId={'0'}
+            name={CONTRACTS[contract].full}
+            collectionWide={true}
             setModal={setShowModal}
             action={ORDER_TYPE.OFFER}
             hash={''}
@@ -292,7 +291,7 @@ export default function Marketplace({
 
 export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
   const contractSlug = params?.contractSlug as string;
-  
+
   return {
     props: {
       wizardsWithLore: await getWizardsWithLore(contractSlug),


### PR DESCRIPTION
I noticed that on smaller screens it's easy to get into a position on the listings page that a large part of the screen is left empty.

### Before
<img width="990" alt="Screenshot 2022-03-19 at 22 04 56" src="https://user-images.githubusercontent.com/89519802/159138340-091c8fc6-3ec5-41b5-a27d-7aa9132f6642.png">

### After
<img width="957" alt="Screenshot 2022-03-19 at 22 06 44" src="https://user-images.githubusercontent.com/89519802/159138403-5300303d-a9f8-4f5a-917b-53c39f7f3b18.png">

With `100vh` set, the listings can take the full window when scrolled down on the page.
