### PR TITLE
feat: Add quantity numbers to treat list

### DIFF
--- a/components/Marketplace/TokenDisplay.tsx
+++ b/components/Marketplace/TokenDisplay.tsx
@@ -166,9 +166,22 @@ const Grain = styled.div`
   background-repeat: repeat;
 `;
 
+const QuantityOverlay = styled.div`
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  color: white;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 5px;
+  border-radius: 50%;
+  font-size: 1rem;
+  z-index: 10;
+`;
+
 export default function TokenDisplay({
   contract,
   tokenId,
+  remainingSupply,
   name,
   price,
   source,
@@ -176,6 +189,7 @@ export default function TokenDisplay({
 }: {
   contract: string;
   tokenId: number;
+  remainingSupply: number;
   name: string;
   price: number;
   source: string;
@@ -184,6 +198,7 @@ export default function TokenDisplay({
   let contractDict = getContract(contract);
   let image = getImage(contract, tokenId, image_url);
   let hasTurnaround = ['Wizards', 'Ponies', 'Souls', 'Warriors'].includes(contractDict.display);
+  let hasMultiples = contractDict.display == 'Treats';
 
   let turnaround = contractDict.display == 'Wizards' ? 
     `https://runes-turnarounds.s3.amazonaws.com/${tokenId}/${tokenId}-walkcycle-nobg.gif` :
@@ -246,6 +261,7 @@ export default function TokenDisplay({
           { source in MARKETS && <MarketIcon src={MARKETS[source].image} title={MARKETS[source].name}/> }
         </ListingInfo>
         <NewFrame/>
+        {hasMultiples && <QuantityOverlay>x{remainingSupply}</QuantityOverlay>}
       </ListingDisplay>
       </SoftLink>
     </Link>

--- a/pages/[contractSlug].tsx
+++ b/pages/[contractSlug].tsx
@@ -165,7 +165,7 @@ export default function Marketplace({
 
   async function fetchListings(reset: boolean) {
     var lists: any = [];
-    var url = API_BASE_URL + "tokens/v5?" + ("collection=" + contract);
+    var url = API_BASE_URL + "tokens/v7?" + ("collection=" + contract);
     setLoaded(false);
 
     if (reset) {
@@ -177,6 +177,7 @@ export default function Marketplace({
       if (reset || continuation != null) {
         const page = await fetch(
           url + '&sortBy=floorAskPrice&limit=50' + 
+          '&includeQuantity=true' + // for erc1155 tokens (i.e. treats)
           (!reset && continuation != '' ? "&continuation=" + continuation : '') +
           (router.query.source ? "&source=" + sourceReplace(router.query.source) : '') +
           getURLAttributes(router.query, contractDict.display)
@@ -299,6 +300,7 @@ export default function Marketplace({
                                   <TokenDisplay
                                     contract={contract}
                                     tokenId={listing.token.tokenId}
+                                    remainingSupply={listing.token.remainingSupply}
                                     name={listing.token.name}
                                     price={listing.market.floorAsk.price?.amount.native}
                                     source={listing.market.floorAsk.source?.id}


### PR DESCRIPTION
Hello tv, this PR add quantity numbers for treats in a similar style as OS does.

I also wanted to add numbers in the single item page put it looks like the gettokenv5 API does not return the item quantity as described in the doc, while with v7 we could no more derive if the last sale has been a buy or a sell (as the lastSale object gives no info about it being a sell to Weth or a buy), what could be done here? I think with the current api there is no way to get both quantity and last sale details without making more requests. What do you think? 

btw I hope you like it 🧙

![image](https://github.com/tv3636/forgotten-market/assets/1212655/807935a3-cf66-4661-b7ff-4e3cb1082cac)
ref: https://opensea.io/collection/athenaeum